### PR TITLE
Rework Heat example and its BMI

### DIFF
--- a/src/main/java/edu/colorado/csdms/bmiheat/BmiHeat.java
+++ b/src/main/java/edu/colorado/csdms/bmiheat/BmiHeat.java
@@ -29,7 +29,6 @@ public class BmiHeat implements BMI {
     {"plate_surface__temperature"};
   
   private Heat model;
-  private HashMap<String, double[]> values;
   private HashMap<String, String> varUnits;
   private HashMap<Integer, String> grids;
   private HashMap<Integer, String> gridType;
@@ -39,7 +38,6 @@ public class BmiHeat implements BMI {
    */
   public BmiHeat() {
     model = null;
-    values = new HashMap<String, double[]>();
     varUnits = new HashMap<String, String>();
     grids = new HashMap<Integer, String>();
     gridType = new HashMap<Integer, String>();
@@ -67,7 +65,6 @@ public class BmiHeat implements BMI {
    * instance.
    */
   private void initializeHelper() {
-    values.put(INPUT_VAR_NAMES[0], flattenArray2D(model.getTemperature()));
     varUnits.put(INPUT_VAR_NAMES[0], "K");
     grids.put(0, INPUT_VAR_NAMES[0]);
     gridType.put(0, "uniform_rectilinear_grid");
@@ -238,15 +235,14 @@ public class BmiHeat implements BMI {
   /** {@inheritDoc} */
   @SuppressWarnings("unchecked")
   @Override
-  public <T> T getValue(String varName) {
-    return (T) values.get(varName).clone();
+  public double[] getValue(String varName) {
+	return flattenArray2D(model.getTemperature());
   }
 
   /** {@inheritDoc} */
-  @SuppressWarnings("unchecked")
   @Override
   public <T> T getValueRef(String varName) {
-    return (T) values.get(varName);
+    return null; // Not implemented
   }
 
   /** {@inheritDoc} */
@@ -345,10 +341,9 @@ public class BmiHeat implements BMI {
   /** {@inheritDoc} */
   @Override
   public void setValue(String varName, double[] src) {
-    double[] varRef = getValueRef(varName);
-    for (int i = 0; i < varRef.length; i++) {
-      varRef[i] = src[i];
-    }
+    int nRows = getGridShape(getVarGrid(varName))[0];
+    int nCols = getGridShape(getVarGrid(varName))[1];
+    model.setTemperature(unflattenArray2D(src, nRows, nCols));
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/edu/colorado/csdms/bmiheat/BmiHeat.java
+++ b/src/main/java/edu/colorado/csdms/bmiheat/BmiHeat.java
@@ -79,18 +79,30 @@ public class BmiHeat implements BMI {
    * @param array2D a 2D array of doubles
    * @return a 1D array of doubles
    */
-  private double[] flattenArray2D(double[][] array2D) {
-    int size1D = 0;
-    for (double[] array : array2D) {
-      size1D += array.length;
-    }
-    double[] array1D = new double[size1D];
-    int pos = 0;
-    for (double[] array : array2D) {
-      System.arraycopy(array, 0, array1D, pos, array.length);
-      pos += array.length;
-    }
+  protected double[] flattenArray2D(double[][] array2D) {
+	int nRows = array2D.length, nCols = array2D[0].length;
+	double[] array1D = new double[(nRows*nCols)];
+      for ( int i = 0; i < nRows; i++ ) {
+	    System.arraycopy(array2D[i], 0, array1D, (i*nCols), nCols);
+      }
     return array1D;
+  }
+
+  /**
+   * A helper that converts a 1D array of doubles into a 2D array using the
+   * shape of the model grid.
+   *
+   * @param array1D a 1D array of doubles
+   * @param nRows the desired number of rows of the 2D array
+   * @param nCols the desired number of columns of the 2D array
+   * @return a 2D array of doubles
+   */
+  protected double[][] unflattenArray2D(double[] array1D, int nRows, int nCols) {
+    double[][] array2D = new double[nRows][nCols];
+    for (int i = 0; i < nRows; i++) {
+        System.arraycopy(array1D, (i*nCols), array2D[i], 0, nCols);
+    }
+    return array2D;
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/edu/colorado/csdms/bmiheat/BmiHeat.java
+++ b/src/main/java/edu/colorado/csdms/bmiheat/BmiHeat.java
@@ -5,7 +5,6 @@ package edu.colorado.csdms.bmiheat;
 
 import java.io.File;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -421,12 +420,12 @@ public class BmiHeat implements BMI {
     System.out.println("- var itemsize: " + bmi.getVarItemsize(var_name));
     System.out.println("- var nbytes: " + bmi.getVarNbytes(var_name));
 
-    // Get default initial temperature field and add an impulse.
+    // Add an impulse to the default initial temperature field.
     double[] temp0 = bmi.getValue(var_name);
     temp0[3*shape[1] + 2] = 100.0;
     bmi.setValue(var_name, temp0);
 
-    // Advance model over several time steps.
+    // Advance the model over several time steps.
     Double currentTime = bmi.getCurrentTime();
     while (currentTime < 1.0) {
       System.out.println("time = " + currentTime.toString());

--- a/src/main/java/edu/colorado/csdms/bmiheat/BmiHeat.java
+++ b/src/main/java/edu/colorado/csdms/bmiheat/BmiHeat.java
@@ -196,7 +196,12 @@ public class BmiHeat implements BMI {
   /** {@inheritDoc} */
   @Override
   public String getVarType(String varName) {
-    return values.get(varName).getClass().getName();
+    if (varName == getOutputVarNames()[0]) {
+      if (model.getTemperature().getClass().getName().contains("D")) {
+        return "double";
+      }
+    }
+    return null;
   }
 
   /** {@inheritDoc} */
@@ -209,7 +214,7 @@ public class BmiHeat implements BMI {
   @Override
   public int getVarItemsize(String varName) {
     int itemSize = 0;
-    if (getVarType(varName).equals("[D")) {
+    if (getVarType(varName).equalsIgnoreCase("double")) {
       itemSize = 8;
     }
     return itemSize;
@@ -218,7 +223,11 @@ public class BmiHeat implements BMI {
   /** {@inheritDoc} */
   @Override
   public int getVarNbytes(String varName) {
-    return getVarItemsize(varName) * values.get(varName).length;
+    if (varName == getOutputVarNames()[0]) {
+      return getVarItemsize(varName) * getGridSize(getVarGrid(varName));
+    } else {
+      return -1;
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/edu/colorado/csdms/heat/Heat.java
+++ b/src/main/java/edu/colorado/csdms/heat/Heat.java
@@ -39,16 +39,16 @@ public class Heat {
       Double xStart, Double yStart, Double alpha) {
 
     shape = new ArrayList<Integer>(Arrays.asList(nRows, nCols));
-    spacing = new ArrayList<Double>(Arrays.asList(dx, dy));
-    origin = new ArrayList<Double>(Arrays.asList(xStart, yStart));
+    spacing = new ArrayList<Double>(Arrays.asList(dy, dx));
+    origin = new ArrayList<Double>(Arrays.asList(yStart, xStart));
     this.alpha = alpha;
     time = 0.0;
 
-    Double minSpacing = Math.min(spacing.get(0), spacing.get(1));
+    Double minSpacing = Math.min(dy, dx);
     timeStep = Math.pow(minSpacing, 2.0) / (4.0 * this.alpha);
 
     // Initialize plate temperature.
-    temperature = new double[shape.get(1)][shape.get(0)];
+    temperature = new double[nRows][nCols];
   }
 
   /**
@@ -248,7 +248,7 @@ public class Heat {
 
     // Place impulse in termperature field.
     double[][] temp0 = heat.getTemperature();
-    temp0[2][3] = 100.0;
+    temp0[3][2] = 100.0;
     heat.setTemperature(temp0);
 
     // Advance model over several time steps.
@@ -259,7 +259,7 @@ public class Heat {
       double[][] temp = heat.getTemperature();
       for (int j = 0; j < heat.getShape().get(0); j++) {
         for (int i = 0; i < heat.getShape().get(1); i++) {
-          System.out.format("%7.2f", temp[i][j]);
+          System.out.format("%7.2f", temp[j][i]);
         }
         System.out.print("\n");
       }

--- a/src/main/java/edu/colorado/csdms/heat/Solve2D.java
+++ b/src/main/java/edu/colorado/csdms/heat/Solve2D.java
@@ -23,12 +23,12 @@ public class Solve2D {
   public static double[][] solve(double[][] temperature, List<Integer> shape,
       List<Double> spacing, Double alpha, Double timeStep) {
 
-    Integer topRowIndex = shape.get(1) - 1;
-    Integer topColIndex = shape.get(0) - 1;
-    Double dx2 = Math.pow(spacing.get(0), 2.0);
-    Double dy2 = Math.pow(spacing.get(1), 2.0);
+    Integer topRowIndex = shape.get(0) - 1;
+    Integer topColIndex = shape.get(1) - 1;
+    Double dx2 = Math.pow(spacing.get(1), 2.0);
+    Double dy2 = Math.pow(spacing.get(0), 2.0);
     Double c = alpha * timeStep / (dx2 + dy2);
-    double[][] newTemperature = new double[shape.get(1)][shape.get(0)];
+    double[][] newTemperature = new double[shape.get(0)][shape.get(1)];
     
     for (int i = 1; i < topRowIndex; i++) {
       for (int j = 1; j < topColIndex; j++) {
@@ -39,12 +39,12 @@ public class Solve2D {
       }
     }
 
-    for (int j = 0; j < shape.get(0); j++) {
+    for (int j = 0; j < shape.get(1); j++) {
       newTemperature[0][j] = 0.0;
       newTemperature[topRowIndex][j] = 0.0;
     }
 
-    for (int i = 0; i < shape.get(1); i++) {
+    for (int i = 0; i < shape.get(0); i++) {
       newTemperature[i][0] = 0.0;
       newTemperature[i][topColIndex] = 0.0;
     }

--- a/src/test/java/edu/colorado/csdms/bmiheat/TestGetAndSetValue.java
+++ b/src/test/java/edu/colorado/csdms/bmiheat/TestGetAndSetValue.java
@@ -136,17 +136,15 @@ public class TestGetAndSetValue {
     BmiHeat component = new BmiHeat();
     component.initialize();
 
-    double[] varRef = component.getValueRef(varName);
-    double[] varNew1 = new double[varRef.length];
+    double[] varNew1 = component.getValue(varName);
     varNew1[0] = 5.0;
 
     component.setValue(varName, varNew1);
 
-    double[] varNew2 = component.getValueRef(varName);
+    double[] varNew2 = component.getValue(varName);
 
-    assertEquals(varRef, varNew2);
     assertNotSame(varNew1, varNew2);
-    assertArrayEquals(varNew2, varNew1, delta);
+    assertArrayEquals(varNew1, varNew2, delta);
   }
 
   /**

--- a/src/test/java/edu/colorado/csdms/bmiheat/TestGetAndSetValue.java
+++ b/src/test/java/edu/colorado/csdms/bmiheat/TestGetAndSetValue.java
@@ -23,6 +23,7 @@ public class TestGetAndSetValue {
   private Double delta; // maximum difference to be considered equal
   private String varName;
   private String varUnits;
+  private String varType;
   private Double initialTempMin;
   private Double initialTempMax;
   private double[] array1D = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
@@ -36,6 +37,7 @@ public class TestGetAndSetValue {
     delta = 0.1;
     varName = "plate_surface__temperature";
     varUnits = "K";
+    varType = "double";
     initialTempMin = 0.0;
     initialTempMax = 20.0;
   }
@@ -54,7 +56,7 @@ public class TestGetAndSetValue {
   public final void testGetVarType() {
     BmiHeat component = new BmiHeat();
     component.initialize();
-    assertEquals("[D", component.getVarType(varName));
+    assertEquals(varType, component.getVarType(varName));
   }
 
   /**

--- a/src/test/java/edu/colorado/csdms/bmiheat/TestGetAndSetValue.java
+++ b/src/test/java/edu/colorado/csdms/bmiheat/TestGetAndSetValue.java
@@ -100,26 +100,6 @@ public class TestGetAndSetValue {
   }
 
   /**
-   * Test method for {@link BmiHeat#getValueRef(java.lang.String)}.
-   */
-  @Test
-  public final void testGetValueRef() {
-    BmiHeat component = new BmiHeat();
-    component.initialize();
-
-    double[] varRef = component.getValueRef(varName);
-    double[] varCpy = component.getValue(varName);
-
-    assertNotSame(varCpy, varRef);
-    assertArrayEquals(varRef, varCpy, delta);
-
-    for (int i = 0; i < 5; i++) {
-      component.update();
-    }
-    assertArrayEquals(varRef, (double[]) component.getValueRef(varName), delta);
-  }
-
-  /**
    * Test method for {@link BmiHeat#getValueAtIndices(java.lang.String, int[])}.
    */
   @Test

--- a/src/test/java/edu/colorado/csdms/bmiheat/TestGetAndSetValue.java
+++ b/src/test/java/edu/colorado/csdms/bmiheat/TestGetAndSetValue.java
@@ -17,12 +17,16 @@ import org.junit.Test;
 public class TestGetAndSetValue {
 
   private static final int SIZEOF_DOUBLE = 8;
+  private static final int NROWS = 4;
+  private static final int NCOLS = 3;
 
   private Double delta; // maximum difference to be considered equal
   private String varName;
   private String varUnits;
   private Double initialTempMin;
   private Double initialTempMax;
+  private double[] array1D = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  private double[][] array2D = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12}};
 
   /**
    * @throws java.lang.Exception
@@ -151,4 +155,29 @@ public class TestGetAndSetValue {
     return; // Not implemented
   }
 
+  /**
+   * Test that a flattened 2D array can be redimensionalized with
+   * {@link BmiHeat#unflattenArray2D(double[], int, int)}.
+   */
+  @Test
+  public final void testUnflatten2dArray() {
+    BmiHeat component = new BmiHeat();
+
+    double[][] new2D = new double[NROWS][NCOLS];
+    new2D = component.unflattenArray2D(array1D, NROWS, NCOLS);
+    assertArrayEquals(array2D[0], new2D[0], delta);
+  }
+
+  /**
+   * Test that a 2D array can be flattened with
+   * {@link BmiHeat#flattenArray2D(double[][])}.
+   */
+  @Test
+  public final void testFlatten2dArray() {
+    BmiHeat component = new BmiHeat();
+
+    double[] new1D = new double[NROWS*NCOLS];
+    new1D = component.flattenArray2D(array2D);
+    assertArrayEquals(array1D, new1D, delta);
+  }
 }

--- a/src/test/java/edu/colorado/csdms/heat/HeatTest.java
+++ b/src/test/java/edu/colorado/csdms/heat/HeatTest.java
@@ -40,11 +40,11 @@ public class HeatTest {
 
     time = 0.0;
     shape = new ArrayList<Integer>(Arrays.asList(nRows, nCols));
-    spacing = new ArrayList<Double>(Arrays.asList(dx, dy));
-    origin = new ArrayList<Double>(Arrays.asList(xStart, yStart));
+    spacing = new ArrayList<Double>(Arrays.asList(dy, dx));
+    origin = new ArrayList<Double>(Arrays.asList(yStart, xStart));
 
     // Initialize plate temperature.
-    temperature = new double[shape.get(1)][shape.get(0)];
+    temperature = new double[nRows][nCols];
   }
 
   /**
@@ -220,12 +220,9 @@ public class HeatTest {
    */
   @Test
   public final void testSetTemperature() {
-    double[][] newTemperature = new double[shape.get(1)][shape.get(0)];
+    double[][] newTemperature = new double[shape.get(0)][shape.get(1)];
     for (int i = 0; i < shape.get(1); i++) {
-      double[] iCol = newTemperature[i];
-      for (int j = 0; j < iCol.length; j++) {
-        iCol[j] = j + 1;
-      }
+      newTemperature[0][i] = i + 10.0;
     }
     heat.setTemperature(newTemperature);
 


### PR DESCRIPTION
This PR contains revisions to the Heat example and its BmiHeat complement.

In Heat, I had incorrectly transposed the shape, spacing, and origin variables, which caused problems downstream when indexing into the 2D arrays of the example.

In BmiHeat, I primarily reworked the *getValue* and *setValue* methods, both of which relied on *getValueRef*, which I removed--Java doesn't have pointer arithmetic, so I can't get the address of the first element of an array to flatten it, a technique we use in the C, C++, Fortran, and Python BMIs. I can't flatten a Java array without losing its reference.

Note that the *getValue* and *setValue* methods are still not optimally implemented (I allocate memory in the BMI to use them), but to fix them, I need to change the BMI. My plan is to make the necessary changes along with the update to BMI v2.0.